### PR TITLE
Do not truncate ctl.log on start

### DIFF
--- a/jobs/service-backup/templates/ctl.erb
+++ b/jobs/service-backup/templates/ctl.erb
@@ -28,7 +28,7 @@ backup_log_file=$log_dir/out.log
 pidfile=/var/vcap/sys/run/service-backup.pid
 
 log() {
-  echo "$(date): $*" > $script_log_file
+  echo "$(date): $*" >> $script_log_file
 }
 export -f log
 


### PR DESCRIPTION
Introduced by https://github.com/pivotal-cf/service-backup-release/commit/3d01e123f736e123a7916d702563611e23e79d76#diff-0cdad82172c9bbc9ee8f6ae2d15225a6.

cc: @jamesjoshuahill 