### PR TITLE
REDVM-656: Update blob packages with new available versions.

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,16 +1,12 @@
-go/go1.21.6.linux-amd64.tar.gz:
-  size: 68973343
-  object_id: 6cc2eab5-fdb1-4db8-554b-3991f94c6323
-  sha: sha256:999805bed7d9039ec3da1a53bfbcafc13e367da52aa823cb60b68ba22d44c616
-libffi/libffi-3.4.4.tar.gz:
-  size: 1362394
-  object_id: 249852d5-2245-498b-41e1-b35a6bfb49c6
-  sha: sha256:d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676
-python/Python-3.12.4.tgz:
-  size: 27211305
-  object_id: d4f09df7-0368-4531-449c-4a6e607679d4
-  sha: sha256:01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9
-sqlite/sqlite-autoconf-3450000.tar.gz:
-  size: 3231697
-  object_id: 0a6c824c-149d-4557-47b9-57c111d08eda
-  sha: sha256:72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436
+libffi/libffi-3.4.6.tar.gz:
+  size: 1391684
+  object_id: 3e8cf1da-9c68-4f5a-61a0-1a8c07a93b1c
+  sha: sha256:b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e
+python/Python-3.12.6.tgz:
+  size: 27009716
+  object_id: 15e25316-681f-4155-7b0a-1a2344b91d57
+  sha: sha256:85a4c1be906d20e5c5a69f2466b00da769c221d6a684acfd3a514dbf5bf10a66
+sqlite/sqlite-autoconf-3460100.tar.gz:
+  size: 3265571
+  object_id: bbbc40df-0fc0-4cc3-704b-ec32239e93e3
+  sha: sha256:67d3fe6d268e6eaddcae3727fce58fcc8e9c53869bdd07a0c61e38ddf2965071

--- a/packages/service-backup_python/packaging
+++ b/packages/service-backup_python/packaging
@@ -6,27 +6,27 @@
 
 set -e
 
-tar zxf sqlite/sqlite-autoconf-3450000.tar.gz
+tar zxf sqlite/sqlite-autoconf-3460100.tar.gz
 
 mkdir ${BOSH_INSTALL_TARGET}/sqlite3
 
-pushd sqlite-autoconf-3450000
+pushd sqlite-autoconf-3460100
   ./configure --prefix=${BOSH_INSTALL_TARGET}/sqlite3
   make
   make install
 popd
 
-tar xvf libffi/libffi-3.4.4.tar.gz
+tar xvf libffi/libffi-3.4.6.tar.gz
 
 mkdir ${BOSH_INSTALL_TARGET}/libffi
 
-pushd libffi-3.4.4
+pushd libffi-3.4.6
   ./configure --prefix=${BOSH_INSTALL_TARGET}/libffi
   make
   make install
 popd
 
-name=Python-3.12.4
+name=Python-3.12.6
 tar zxf python/${name}.tgz
 
 pushd $name

--- a/packages/service-backup_python/spec
+++ b/packages/service-backup_python/spec
@@ -7,6 +7,6 @@
 ---
 name: service-backup_python
 files:
-  - python/Python-3.12.4.tgz
-  - sqlite/sqlite-autoconf-3450000.tar.gz
-  - libffi/libffi-3.4.4.tar.gz
+  - python/Python-3.12.6.tgz
+  - sqlite/sqlite-autoconf-3460100.tar.gz
+  - libffi/libffi-3.4.6.tar.gz


### PR DESCRIPTION
CI -> https://runway-ci.eng.vmware.com/teams/tanzu-redis/pipelines/amit-4.0-tile?group=service-backup-release

Update blobs for 
python to 3.12.6 from 3.12.4
libffi to 3.4.6 from 3.4.4
sqlite-autoconf to 3460100 from 3450000