### PR TITLE
TNZ-38100: updates the bucket-name due to gcp-migration

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -9,4 +9,4 @@ final_name: service-backup
 blobstore:
   provider: gcs
   options:
-    bucket_name: service-backup-bosh-release-blobs
+    bucket_name: cf-redis-service-backup-bosh-release-blobs


### PR DESCRIPTION
Bucket name change:
service-backup-bosh-release-blobs -> cf-redis-service-backup-bosh-release-blobs