### PR TITLE
TNZ-100061: ai-assisted=yes wire force_path_style into S3 backup config

### DIFF
--- a/jobs/service-backup/templates/backup.yml.erb
+++ b/jobs/service-backup/templates/backup.yml.erb
@@ -66,6 +66,7 @@ def set_destination_defaults(type, destination)
     's3' => lambda {
       destination["config"]["endpoint_url"] = "" if destination["config"]["endpoint_url"].nil?
       destination["config"]["region"] = "" if destination["config"]["region"].nil?
+      destination["config"]["force_path_style"] = false if destination["config"]["force_path_style"].nil?
     },
     'azure' => lambda {},
     'gcs' => lambda {}

--- a/spec/backup_template_spec.rb
+++ b/spec/backup_template_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'backup job config rendering' do
             "bucket_name" => "test",
             "bucket_path" => "foo/bar",
             "access_key_id" => "*4!'T#f\"J}A,~Da{)4{jz",
-            "secret_access_key" => "itsasecret"
+            "secret_access_key" => "itsasecret",
+            "force_path_style" => false
           }
         }
       ],
@@ -44,6 +45,24 @@ RSpec.describe 'backup job config rendering' do
       "exit_if_in_progress" => false,
       "service_identifier_executable" => nil
     })}
+  end
+
+  context 'when force_path_style is not set in the manifest' do
+    let(:manifest_file) { 'spec/fixtures/valid_s3.yml' }
+    subject{ YAML.load(renderer.render('jobs/service-backup/templates/backup.yml.erb')) }
+
+    it 'defaults force_path_style to false' do
+      expect(subject["destinations"][0]["config"]["force_path_style"]).to eq(false)
+    end
+  end
+
+  context 'when force_path_style is set to true in the manifest (e.g. MinIO)' do
+    let(:manifest_file) { 'spec/fixtures/valid_s3_with_force_path_style.yml' }
+    subject{ YAML.load(renderer.render('jobs/service-backup/templates/backup.yml.erb')) }
+
+    it 'passes force_path_style: true through to the rendered config unchanged' do
+      expect(subject["destinations"][0]["config"]["force_path_style"]).to eq(true)
+    end
   end
 
   context 'when the manifest contains a custom backup user' do
@@ -418,7 +437,8 @@ RSpec.describe 'backup job config rendering' do
             "bucket_name" => "test",
             "bucket_path" => "foo/bar",
             "access_key_id" => "key",
-            "secret_access_key" => "itsasecret"
+            "secret_access_key" => "itsasecret",
+            "force_path_style" => false
           }
         }
       ],

--- a/spec/fixtures/valid_s3_with_force_path_style.yml
+++ b/spec/fixtures/valid_s3_with_force_path_style.yml
@@ -1,0 +1,71 @@
+# Copyright (C) 2016-Present Pivotal Software, Inc. All rights reserved.
+# This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+---
+name: service-backup
+
+director_uuid: dc4e8b29-2f3a-4051-8b66-39193791a57b
+
+releases:
+- name: service-backup
+  version: latest
+
+properties:
+  service-backup:
+    destinations:
+      - type: s3
+        config:
+          endpoint_url: http://minio.example.com
+          region: us-east-1
+          bucket_name: test
+          bucket_path: foo/bar
+          access_key_id: '*4!''T#f"J}A,~Da{)4{jz'
+          secret_access_key: itsasecret
+          force_path_style: true
+    source_folder: /foo
+    source_executable: whoami
+    cron_schedule: '*/5 * * * * *'
+    cleanup_executable: somecleanup
+    missing_properties_message: custom message
+
+jobs:
+- name: service-backup
+  instances: 1
+  resource_pool: service-backup
+  networks:
+  - name: service-backup
+  templates:
+  - {release: service-backup, name: service-backup}
+
+networks:
+- name: service-backup
+  subnets:
+  - range: 10.244.8.0/30
+    reserved: [10.244.8.1]
+    cloud_properties: {}
+  - range: 10.244.8.4/30
+    reserved: [10.244.8.5]
+    cloud_properties: {}
+
+resource_pools:
+- name: service-backup
+  network: service-backup
+  cloud_properties: {}
+  stemcell:
+    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+    version: latest
+
+compilation:
+  workers: 1
+  network: service-backup
+  cloud_properties: {}
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000


### PR DESCRIPTION
TNZ-100061: ai-assisted=yes wire force_path_style into S3 backup config

- backup.yml.erb: default force_path_style to false for S3 destinations so the key is always present in the rendered config (consumed by factory.go)
- backup_template_spec.rb: assert force_path_style: false in rendered output
- Bump service-backup submodule to pick up AWS SDK v2 migration, usePathStyle support in S3 client, force_path_style mapping in upload/factory.go, and unconditional cleanup after upload failure (TNZ-100061 fix)